### PR TITLE
Feature/assign universal ideas

### DIFF
--- a/components/UniversalIdeasPage/AssignSelect.js
+++ b/components/UniversalIdeasPage/AssignSelect.js
@@ -1,0 +1,17 @@
+export default function AssignSelect({ entries, idea, onIdeaAssign }) {
+  function handleChange(event) {
+    event.preventDefault();
+    const assignedName = event.target.value;
+    const assignedIdea = idea;
+    onIdeaAssign(assignedName, assignedIdea);
+  }
+
+  return (
+    <select onChange={handleChange}>
+      <option value="selected">---Idee zuweisen---</option>
+      {entries.map((entry) => (
+        <option key={entry.id}>{entry.name}</option>
+      ))}
+    </select>
+  );
+}

--- a/components/UniversalIdeasPage/AssignSelect.js
+++ b/components/UniversalIdeasPage/AssignSelect.js
@@ -6,6 +6,7 @@ export default function AssignSelect({ entries, idea, onIdeaAssign }) {
     const assignedName = event.target.value;
     const assignedIdea = idea;
     onIdeaAssign(assignedName, assignedIdea);
+    event.target.value = "selected";
   }
 
   return (

--- a/components/UniversalIdeasPage/AssignSelect.js
+++ b/components/UniversalIdeasPage/AssignSelect.js
@@ -1,3 +1,5 @@
+import styled from "styled-components";
+
 export default function AssignSelect({ entries, idea, onIdeaAssign }) {
   function handleChange(event) {
     event.preventDefault();
@@ -7,11 +9,20 @@ export default function AssignSelect({ entries, idea, onIdeaAssign }) {
   }
 
   return (
-    <select onChange={handleChange}>
-      <option value="selected">---Idee zuweisen---</option>
+    <StyledSelect onChange={handleChange}>
+      <option value="selected">--Wem könnte das gefallen?--</option>
       {entries.map((entry) => (
         <option key={entry.id}>{entry.name}</option>
       ))}
-    </select>
+    </StyledSelect>
   );
 }
+
+const StyledSelect = styled.select`
+  background-color: #f4f4f8;
+  color: gray;
+  margin: 0 1rem 0 1rem;
+  padding: 0.2rem;
+  font-family: PTSans;
+  border-radius: 3px;
+`;

--- a/components/UniversalIdeasPage/UniversalIdeas.js
+++ b/components/UniversalIdeasPage/UniversalIdeas.js
@@ -27,17 +27,12 @@ export default function UniversalIdeas({
           <StyledEditInput
             type="text"
             name="adaptedIdea"
-            defaultValue={idea.idea}
+            defaultValue={idea}
           ></StyledEditInput>
           <StyledEditButton type="submit">OK</StyledEditButton>
         </StyledForm>
       ) : (
         <StyledIdeaContainer>
-          <AssignSelect
-            entries={entries}
-            onIdeaAssign={onIdeaAssign}
-            idea={idea}
-          />
           <StyledIdea>{idea}</StyledIdea>
           <StyledButton
             type="button"
@@ -46,6 +41,11 @@ export default function UniversalIdeas({
           >
             ✍🏼
           </StyledButton>
+          <AssignSelect
+            entries={entries}
+            onIdeaAssign={onIdeaAssign}
+            idea={idea}
+          />
           <StyledButton
             type="button"
             aria-label="Delete-Button"
@@ -84,12 +84,12 @@ const StyledEditButton = styled.button`
 
 const StyledIdeaContainer = styled.div`
   display: grid;
-  grid-template-columns: 10% 60% 15% 15%;
+  grid-template-columns: 80% 20%;
   margin: auto auto 10px auto;
   width: 90%;
   word-wrap: break-word;
   background-color: #e6e6ea;
-  padding: 15px;
+  padding: 10px 5px 10px 5px;
   border-radius: 5px;
   align-items: center;
 `;
@@ -109,4 +109,5 @@ const StyledButton = styled.button`
   border-radius: 5px;
   margin: 3px;
   font-size: 1.25rem;
+  justify-self: end;
 `;

--- a/components/UniversalIdeasPage/UniversalIdeas.js
+++ b/components/UniversalIdeasPage/UniversalIdeas.js
@@ -1,11 +1,14 @@
 import styled from "styled-components";
 import { useState } from "react";
+import AssignSelect from "./AssignSelect";
 
 export default function UniversalIdeas({
   idea,
   id,
   onUpdateIdea,
   onDeleteIdea,
+  entries,
+  onIdeaAssign,
 }) {
   const [edit, setEdit] = useState(false);
 
@@ -30,7 +33,12 @@ export default function UniversalIdeas({
         </StyledForm>
       ) : (
         <StyledIdeaContainer>
-          <StyledIdea>{idea.idea}</StyledIdea>
+          <AssignSelect
+            entries={entries}
+            onIdeaAssign={onIdeaAssign}
+            idea={idea}
+          />
+          <StyledIdea>{idea}</StyledIdea>
           <StyledButton
             type="button"
             aria-label="Edit-Button"
@@ -76,7 +84,7 @@ const StyledEditButton = styled.button`
 
 const StyledIdeaContainer = styled.div`
   display: grid;
-  grid-template-columns: 70% 15% 15%;
+  grid-template-columns: 10% 60% 15% 15%;
   margin: auto auto 10px auto;
   width: 90%;
   word-wrap: break-word;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,3 @@
-import { NEXT_CLIENT_SSR_ENTRY_SUFFIX } from "next/dist/shared/lib/constants";
 import GlobalStyles from "../components/GlobalStyles";
 import { useLocalStorage } from "../helpers/hooks";
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -53,21 +53,21 @@ function MyApp({ Component, pageProps }) {
   }
 
   function handleIdeaAssign(assignedName, assignedIdea) {
-    setEntries(
-      entries.map((entry) => {
-        const newIdeaKey = !entry.ideas
-          ? assignedIdea
-          : entry.ideas + ", " + assignedIdea;
-        if (assignedName === entry.name) {
-          return { ...entry, ideas: newIdeaKey };
-        } else {
-          return entry;
-        }
-      })
-    );
+    if (confirm("Möchtest du dieser Person diese Idee zuweisen?")) {
+      setEntries(
+        entries.map((entry) => {
+          const newIdeaKey = !entry.ideas
+            ? assignedIdea
+            : entry.ideas + ", " + assignedIdea;
+          if (assignedName === entry.name) {
+            return { ...entry, ideas: newIdeaKey };
+          } else {
+            return entry;
+          }
+        })
+      );
+    }
   }
-
-  console.log("entries", entries);
 
   return (
     <>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -52,6 +52,23 @@ function MyApp({ Component, pageProps }) {
     );
   }
 
+  function handleIdeaAssign(assignedName, assignedIdea) {
+    setEntries(
+      entries.map((entry) => {
+        const newIdeaKey = !entry.ideas
+          ? assignedIdea
+          : entry.ideas + ", " + assignedIdea;
+        if (assignedName === entry.name) {
+          return { ...entry, ideas: newIdeaKey };
+        } else {
+          return entry;
+        }
+      })
+    );
+  }
+
+  console.log("entries", entries);
+
   return (
     <>
       <GlobalStyles />
@@ -62,6 +79,7 @@ function MyApp({ Component, pageProps }) {
         onDelete={handleDelete}
         onUpdateEntryNotes={handleUpdateEntryNotes}
         onUpdateIdeas={handleUpdateIdeas}
+        onIdeaAssign={handleIdeaAssign}
         entries={entries}
       />
     </>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -53,7 +53,7 @@ function MyApp({ Component, pageProps }) {
   }
 
   function handleIdeaAssign(assignedName, assignedIdea) {
-    if (confirm("Möchtest du dieser Person diese Idee zuweisen?")) {
+    if (confirm(`Möchtest du ${assignedName} diese Idee zuweisen?`)) {
       setEntries(
         entries.map((entry) => {
           const newIdeaKey = !entry.ideas

--- a/pages/universal-ideas.js
+++ b/pages/universal-ideas.js
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { useLocalStorage } from "../helpers/hooks";
 import { Fragment } from "react";
 
-export default function UniversalIdeasPage() {
+export default function UniversalIdeasPage({ entries, onIdeaAssign }) {
   const [ideas, setIdeas] = useLocalStorage("ideas", []);
 
   function handleCreateIdea(newIdea) {
@@ -32,7 +32,6 @@ export default function UniversalIdeasPage() {
     setIdeas([...updatedIdea]);
   }
 
-  console.log("ideas", ideas);
   return (
     <>
       <Header />
@@ -41,10 +40,12 @@ export default function UniversalIdeasPage() {
         {ideas.map((idea) => (
           <Fragment key={idea.id}>
             <UniversalIdeas
-              idea={idea}
+              idea={idea.idea}
               onUpdateIdea={handleUpdateIdea}
               onDeleteIdea={handleDeleteIdea}
+              onIdeaAssign={onIdeaAssign}
               id={idea.id}
+              entries={entries}
             />
           </Fragment>
         ))}


### PR DESCRIPTION
You can now assign the general ideas on the third page to a person that is in your calendar. Ideas can be assigned to several people, so the idea is not deleted after assigning. When going to the person's profile page, you can now see the added idea right after the previously added ideas. 